### PR TITLE
Optimisations and bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ plgx/*
 release_checklist.txt
 HIBPOfflineCheck.plgx.asc
 *temp.bat
+*.csproj.user

--- a/HIBPOfflineCheckExt.cs
+++ b/HIBPOfflineCheckExt.cs
@@ -14,6 +14,7 @@ using KeePassLib.Utility;
 using KeePass.Util;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
+using KeePass.Util.Spr;
 
 namespace HIBPOfflineCheck
 {
@@ -189,7 +190,9 @@ namespace HIBPOfflineCheck
 
             using (var sha1 = new SHA1CryptoServiceProvider())
             {
-                var pwd_sha_bytes = sha1.ComputeHash(PasswordEntry.Strings.Get(PwDefs.PasswordField).ReadUtf8());
+                var password = SprEngine.Compile(PasswordEntry.Strings.GetSafe(PwDefs.PasswordField).ReadString(), new SprContext(PasswordEntry,Host.Database, SprCompileFlags.All));
+
+                var pwd_sha_bytes = sha1.ComputeHash(UTF8Encoding.UTF8.GetBytes(password));
                 var sb = new StringBuilder(2 * pwd_sha_bytes.Length);
 
                 foreach (byte b in pwd_sha_bytes)

--- a/HIBPOfflineCheckExt.cs
+++ b/HIBPOfflineCheckExt.cs
@@ -12,6 +12,8 @@ using KeePassLib.Security;
 using System.Diagnostics;
 using KeePassLib.Utility;
 using KeePass.Util;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
 
 namespace HIBPOfflineCheck
 {
@@ -180,30 +182,38 @@ namespace HIBPOfflineCheck
             return (strColumnName == PluginOptions.ColumnName);
         }
 
+        [SuppressMessage("Microsoft.Usage", "CA2202:Do not dispose objects multiple times", Justification = "Dispose is idempotent")]
         private void GetPasswordStatus()
         {
-            SHA1 sha1 = new SHA1CryptoServiceProvider();
+            var pwd_sha_str = String.Empty;
 
-            var pwd_sha_bytes = sha1.ComputeHash(PasswordEntry.Strings.Get(PwDefs.PasswordField).ReadUtf8());
-            var pwd_sha_str = "";
-            foreach (byte b in pwd_sha_bytes)
+            using (var sha1 = new SHA1CryptoServiceProvider())
             {
-                pwd_sha_str += b.ToString("x2");
+                var pwd_sha_bytes = sha1.ComputeHash(PasswordEntry.Strings.Get(PwDefs.PasswordField).ReadUtf8());
+                var sb = new StringBuilder(2 * pwd_sha_bytes.Length);
+
+                foreach (byte b in pwd_sha_bytes)
+                {
+                    sb.AppendFormat("{0:X2}", b);
+                }
+                pwd_sha_str = sb.ToString();
             }
-            pwd_sha_str = pwd_sha_str.ToUpperInvariant();
 
             var latestFile = PluginOptions.HIBPFileName;
 
-            if (File.Exists(latestFile) == false)
+            if (!File.Exists(latestFile))
             {
                 Status = "HIBP file not found";
                 return;
             }
 
+            FileStream fs = null;
+            StreamReader sr = null;
+
             try
             {
-                FileStream fs = File.OpenRead(latestFile);
-                StreamReader sr = new StreamReader(fs);
+                fs = File.OpenRead(latestFile);
+                sr = new StreamReader(fs);
 
                 string line;
                 Status = PluginOptions.SecureText;
@@ -225,7 +235,7 @@ namespace HIBPOfflineCheck
                     if (sr.EndOfStream) break;
 
                     // We may have read only a partial line so read again to make sure we get a full line
-                    if (middle > 0) line = sr.ReadLine() ?? "";
+                    if (middle > 0) line = sr.ReadLine() ?? String.Empty;
 
                     int compare = String.Compare(pwd_sha_str, line.Substring(0, sha_len), StringComparison.Ordinal);
 
@@ -251,13 +261,22 @@ namespace HIBPOfflineCheck
                         break;
                     }
                 }
-
-                sr.Close();
-                fs.Close();
             }
-            catch (Exception)
+            catch
             {
                 Status = "Failed to read HIBP file";
+            }
+            finally
+            {
+                if (sr != null)
+                {
+                    sr.Dispose();
+                }
+
+                if (fs != null)
+                {
+                    fs.Dispose();
+                }
             }
         }
 

--- a/Util/build_plgx.bat
+++ b/Util/build_plgx.bat
@@ -1,5 +1,6 @@
 set PluginRoot=..
 set KeePassExe=%PluginRoot%\bin\Debug\KeePass.exe
+Set BuildPath=%~dp0
 
 xcopy /Y %PluginRoot%\Properties\AssemblyInfo.cs plgx\Properties\
 xcopy /Y %PluginRoot%\HIBPOfflineCheck.csproj plgx\
@@ -13,9 +14,8 @@ xcopy /Y %PluginRoot%\Resources\Nuvola\B48x48_KOrganizer.png plgx\Resources\Nuvo
 xcopy /Y %PluginRoot%\Properties\Resources.Designer.cs plgx\Properties\
 xcopy /Y %PluginRoot%\Properties\Resources.resx plgx\Properties\
 
-%KeePassExe% --plgx-create %~dp0plgx
+%KeePassExe% --plgx-create "%BuildPath%plgx"
 
-@ rem run the hole .bat from an existing command line, otherwise the file won't be moved
-move /Y %~dp0plgx.plgx %PluginRoot%\HIBPOfflineCheck.plgx
+move /Y "%BuildPath%plgx.plgx" %PluginRoot%\HIBPOfflineCheck.plgx
 
-rmdir /S /Q %~dp0plgx
+rmdir /S /Q "%BuildPath%plgx


### PR DESCRIPTION
Code optimizations:
 - properly dispose resources (e.g.: SHA1CryptoServiceProvider, FileStream, StreamReader);
 - use StringBuilder instead of string concatenations;
 - fix Code Analysis warnings.

Bug fixes:
 - fixed issue with referenced password field that was causing incorrect Pwned status to be shown. Password field is compiled before SHA-1 hashing;
 - fixed build script to work with paths containing spaces;

P.S. Feel free to merge (or cherry pick) these changes if you find them useful. 

