### PR TITLE
cleanup and bugfixes

### DIFF
--- a/HIBPOfflineCheck.csproj
+++ b/HIBPOfflineCheck.csproj
@@ -51,6 +51,7 @@
     <Compile Include="HIBPOfflineCheckOptions.Designer.cs">
       <DependentUpon>HIBPOfflineCheckOptions.cs</DependentUpon>
     </Compile>
+    <Compile Include="HIBPOfflineColumnProv.cs" />
     <Compile Include="Options.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\Resources.Designer.cs">

--- a/HIBPOfflineCheckExt.cs
+++ b/HIBPOfflineCheckExt.cs
@@ -1,47 +1,31 @@
 ﻿using System;
 using System.Windows.Forms;
-
-using KeePass.Forms;
 using KeePass.Plugins;
-using KeePass.UI;
-
-using KeePassLib;
-using System.Security.Cryptography;
 using System.IO;
-using KeePassLib.Security;
-using System.Diagnostics;
 using KeePassLib.Utility;
 using KeePass.Util;
-using System.Text;
-using KeePass.Util.Spr;
 
 namespace HIBPOfflineCheck
 {
     public sealed class HIBPOfflineCheckExt : Plugin
     {
-        private HIBPOfflineColumnProv prov = null;
-        private static IPluginHost PluginHost = null;
-
-        internal static IPluginHost Host
-        {
-            get { return PluginHost; }
-        }
-
-        private Options options = null;
+        internal static IPluginHost Host { get; private set; }
+        private HIBPOfflineColumnProv _prov;
+        private Options _options;
 
         public override bool Initialize(IPluginHost host)
         {
             Terminate();
 
             if (host == null) return false;
+            
+            Host = host;
+            _prov = new HIBPOfflineColumnProv() { Host = host };
 
-            PluginHost = host;
-            prov = new HIBPOfflineColumnProv() { Host = host };
+            _options = LoadOptions();
+            _prov.PluginOptions = _options;
 
-            options = LoadOptions();
-            prov.PluginOptions = options;
-
-            PluginHost.ColumnProviderPool.Add(prov);
+            Host.ColumnProviderPool.Add(_prov);
 
             return true;
         }
@@ -51,7 +35,7 @@ namespace HIBPOfflineCheck
             if (t == PluginMenuType.Main)
             {
                 ToolStripMenuItem tsMenuItem = new ToolStripMenuItem("HIBP Offline Check...");
-                tsMenuItem.Click += new EventHandler(ToolsMenuItemClick);
+                tsMenuItem.Click += ToolsMenuItemClick;
                 return tsMenuItem;
             }
 
@@ -64,10 +48,10 @@ namespace HIBPOfflineCheck
             optionsForm.Show();
         }
 
-        private string GetDefaultFileName()
+        private static string GetDefaultFileName()
         {
             string appdir = UrlUtil.GetFileDirectory(WinUtil.GetExecutable(), false, true);
-            var files = Directory.GetFiles(appdir, @"pwned-passwords-ordered*.txt");
+            var files = Directory.GetFiles(appdir, @"pwned-passwords-sha1-ordered*.txt");
             if (files.Length == 0)
             {
                 return "";
@@ -96,58 +80,57 @@ namespace HIBPOfflineCheck
 
         public override void Terminate()
         {
-            if (PluginHost == null) return;
+            if (Host == null) return;
 
-            PluginHost.ColumnProviderPool.Remove(prov);
-            prov = null;
+            Host.ColumnProviderPool.Remove(_prov);
+            _prov = null;
 
-            PluginHost = null;
+            Host = null;
         }
 
         public Options LoadOptions()
         {
-            var config = PluginHost.CustomConfig;
+            var config = Host.CustomConfig;
 
             Options options = new Options()
             {
-                HIBPFileName = config.GetString(Options.Names.HIBPFileName, GetDefaultFileName()),
-                ColumnName = config.GetString(Options.Names.ColumnName, "Have I been pwned?"),
-                SecureText = config.GetString(Options.Names.SecureText, "Secure"),
-                InsecureText = config.GetString(Options.Names.InsecureText, "Pwned"),
-                BreachCountDetails = config.GetBool(Options.Names.BreachCountDetails, true),
-                WarningDialog = config.GetBool(Options.Names.WarningDialog, false),
-                WarningDialogText = XmlUnescape(config.GetString(Options.Names.WarningDialogText,
-                    "WARNING - INSECURE PASSWORD\r\n\r\nThis password is insecure and publicly known"))
+                HIBPFileName = config.GetString(Options.Names.HIBP_FILE_NAME) ?? GetDefaultFileName(),
+                ColumnName = config.GetString(Options.Names.COLUMN_NAME) ?? "Have I been pwned?",
+                SecureText = config.GetString(Options.Names.SECURE_TEXT) ?? "Secure",
+                InsecureText = config.GetString(Options.Names.INSECURE_TEXT) ?? "Pwned",
+                BreachCountDetails = config.GetBool(Options.Names.BREACH_COUNT_DETAILS, true),
+                WarningDialog = config.GetBool(Options.Names.WARNING_DIALOG, false),
+                WarningDialogText = XmlUnescape(config.GetString(Options.Names.WARNING_DIALOG_TEXT) ?? "WARNING - INSECURE PASSWORD\r\n\r\nThis password is insecure and publicly known")
             };
 
-            this.options = options;
-            prov.PluginOptions = options;
+            _options = options;
+            _prov.PluginOptions = options;
 
             return options;
         }
 
         public void SaveOptions(Options options)
         {
-            var config = PluginHost.CustomConfig;
+            var config = Host.CustomConfig;
 
-            config.SetString(Options.Names.HIBPFileName, options.HIBPFileName);
-            config.SetString(Options.Names.ColumnName, options.ColumnName);
-            config.SetString(Options.Names.SecureText, options.SecureText);
-            config.SetString(Options.Names.InsecureText, options.InsecureText);
-            config.SetBool(Options.Names.BreachCountDetails, options.BreachCountDetails);
-            config.SetBool(Options.Names.WarningDialog, options.WarningDialog);
-            config.SetString(Options.Names.WarningDialogText, XmlEscape(options.WarningDialogText));
+            config.SetString(Options.Names.HIBP_FILE_NAME, options.HIBPFileName);
+            config.SetString(Options.Names.COLUMN_NAME, options.ColumnName);
+            config.SetString(Options.Names.SECURE_TEXT, options.SecureText);
+            config.SetString(Options.Names.INSECURE_TEXT, options.InsecureText);
+            config.SetBool(Options.Names.BREACH_COUNT_DETAILS, options.BreachCountDetails);
+            config.SetBool(Options.Names.WARNING_DIALOG, options.WarningDialog);
+            config.SetString(Options.Names.WARNING_DIALOG_TEXT, XmlEscape(options.WarningDialogText));
 
-            this.options = options;
-            prov.PluginOptions = options;
+            _options = options;
+            _prov.PluginOptions = options;
         }
 
-        public static string XmlEscape(string unescaped)
+        private static string XmlEscape(string unescaped)
         {
             return unescaped.Replace(Environment.NewLine, "&#xD;&#xA;");
         }
 
-        public static string XmlUnescape(string escaped)
+        private static string XmlUnescape(string escaped)
         {
             return escaped.Replace("&#xD;&#xA;", Environment.NewLine);
         }
@@ -158,241 +141,6 @@ namespace HIBPOfflineCheck
             {
                 return "https://raw.githubusercontent.com/mihaifm/HIBPOfflineCheck/master/version.txt";
             }
-        }
-    }
-
-    public sealed class HIBPOfflineColumnProv : ColumnProvider
-    {
-        private string Status { get; set; }
-        private PwEntry PasswordEntry { get; set; }
-
-        public IPluginHost Host { get; set; }
-        public Options PluginOptions { get; set; }
-
-        private bool insecureWarning = false;
-        private bool passwordEdited = false;
-
-        public HIBPOfflineColumnProv()
-        {
-            HIBPOfflineCheckExt.Host.MainWindow.EntryContextMenu.Opening += ContextMenuStrip_Opening;
-        }
-
-        public override string[] ColumnNames
-        {
-            get { return new string[] { PluginOptions.ColumnName }; }
-        }
-
-        public override bool SupportsCellAction(string strColumnName)
-        {
-            return (strColumnName == PluginOptions.ColumnName);
-        }
-
-        private void GetPasswordStatus()
-        {
-            var pwd_sha_str = String.Empty;
-
-            using (var sha1 = new SHA1CryptoServiceProvider())
-            {
-                var context = new SprContext(PasswordEntry, Host.Database, SprCompileFlags.All);
-                var password = SprEngine.Compile(PasswordEntry.Strings.GetSafe(PwDefs.PasswordField).ReadString(), context);
-
-                var pwd_sha_bytes = sha1.ComputeHash(UTF8Encoding.UTF8.GetBytes(password));
-                var sb = new StringBuilder(2 * pwd_sha_bytes.Length);
-
-                foreach (byte b in pwd_sha_bytes)
-                {
-                    sb.AppendFormat("{0:X2}", b);
-                }
-                pwd_sha_str = sb.ToString();
-            }
-
-            var latestFile = PluginOptions.HIBPFileName;
-
-            if (!File.Exists(latestFile))
-            {
-                Status = "HIBP file not found";
-                return;
-            }
-
-            using (FileStream fs = File.OpenRead(latestFile))
-            using (StreamReader sr = new StreamReader(fs))
-            {
-                try
-                {
-                    string line;
-                    Status = PluginOptions.SecureText;
-                    int sha_len = pwd_sha_str.Length;
-
-                    var low = 0L;
-                    var high = fs.Length;
-
-                    while (low <= high)
-                    {
-                        var middle = (low + high + 1) / 2;
-                        fs.Seek(middle, SeekOrigin.Begin);
-
-                        // Resync with base stream after seek
-                        sr.DiscardBufferedData();
-
-                        line = sr.ReadLine();
-
-                        if (sr.EndOfStream) break;
-
-                        // We may have read only a partial line so read again to make sure we get a full line
-                        if (middle > 0) line = sr.ReadLine() ?? String.Empty;
-
-                        int compare = String.Compare(pwd_sha_str, line.Substring(0, sha_len), StringComparison.Ordinal);
-
-                        if (compare < 0)
-                        {
-                            high = middle - 1;
-                        }
-                        else if (compare > 0)
-                        {
-                            low = middle + 1;
-                        }
-                        else
-                        {
-                            string[] tokens = line.Split(':');
-                            Status = PluginOptions.InsecureText;
-                            insecureWarning = true;
-
-                            if (PluginOptions.BreachCountDetails)
-                            {
-                                Status += " (password count: " + tokens[1].Trim() + ")";
-                            }
-
-                            break;
-                        }
-                    }
-                }
-                catch
-                {
-                    Status = "Failed to read HIBP file";
-                }
-            }
-        }
-
-        public override void PerformCellAction(string strColumnName, PwEntry pe)
-        {
-            if (strColumnName == null || pe == null) { Debug.Assert(false); return; }
-            if (strColumnName != PluginOptions.ColumnName) { return; }
-
-            PasswordEntry = pe;
-
-            GetPasswordStatus();
-            UpdateStatus();
-        }
-
-        private void PwdTouchedHandler(object sender, ObjectTouchedEventArgs e)
-        {
-            PwEntry pe = sender as PwEntry;
-            if (e.Modified)
-            {
-                passwordEdited = true;
-                PerformCellAction(PluginOptions.ColumnName, pe);
-            }
-        }
-
-        public override string GetCellData(string strColumnName, PwEntry pe)
-        {
-            pe.Touched -= this.PwdTouchedHandler;
-            pe.Touched += this.PwdTouchedHandler;
-
-            return pe.Strings.GetSafe(PluginOptions.ColumnName).ReadString();
-        }
-
-        private void UpdateStatus()
-        {
-            MainForm mainForm = HIBPOfflineCheckExt.Host.MainWindow;
-            ListView lv = (mainForm.Controls.Find("m_lvEntries", true)[0] as ListView);
-
-            UIScrollInfo scroll = UIUtil.GetScrollInfo(lv, true);
-
-            PasswordEntry.Strings.Set(PluginOptions.ColumnName, new ProtectedString(true, Status));
-
-            mainForm.UpdateUI(false, null, false, null, true, null, true);
-
-            UIUtil.Scroll(lv, scroll, true);
-
-            if (insecureWarning && passwordEdited && PluginOptions.WarningDialog)
-            {
-                MessageBox.Show(PluginOptions.WarningDialogText,
-                    "HIBP Offline Check", MessageBoxButtons.OK, MessageBoxIcon.Warning);
-            }
-
-            insecureWarning = false;
-            passwordEdited = false;
-        }
-
-        private void ContextMenuStrip_Opening(object sender, System.ComponentModel.CancelEventArgs e)
-        {
-            MainForm mainForm = HIBPOfflineCheckExt.Host.MainWindow;
-            ToolStripItem[] items = mainForm.EntryContextMenu.Items.Find("m_ctxEntryMassModify", true);
-
-            if (items.Length > 0)
-            {
-                ToolStripMenuItem ctxEntryMassModify = items[0] as ToolStripMenuItem;
-
-                ToolStripItem[] hibpItems = ctxEntryMassModify.DropDownItems.Find("m_ctxEntryHIBP", true);
-
-                if (hibpItems.Length == 0)
-                {
-                    ToolStripSeparator separator = new ToolStripSeparator();
-                    ctxEntryMassModify.DropDownItems.Add(separator);
-
-                    ToolStripMenuItem hibpMenuItem = new ToolStripMenuItem()
-                    {
-                        Name = "m_ctxEntryHIBP",
-                        Text = "Have I been pwned?"
-                    };
-
-                    hibpMenuItem.Click += this.OnMenuHIBP;
-                    ctxEntryMassModify.DropDownItems.Add(hibpMenuItem);
-
-                    ToolStripMenuItem hibpClearMenuItem = new ToolStripMenuItem()
-                    {
-                        Name = "m_ctxEntryHIBPClear",
-                        Text = "Clear pwned status"
-                    };
-
-                    hibpClearMenuItem.Click += this.OnMenuHIBPClear;
-                    ctxEntryMassModify.DropDownItems.Add(hibpClearMenuItem);
-
-                }
-            }
-        }
-
-        private delegate void UpdateStatusDelegate();
-
-        private void OnMenuHIBP(object sender, EventArgs e)
-        {
-            MainForm mainForm = HIBPOfflineCheckExt.Host.MainWindow;
-            PwEntry[] selectedEntries = mainForm.GetSelectedEntries();
-
-            foreach (PwEntry pwEntry in selectedEntries)
-            {
-                PasswordEntry = pwEntry;
-
-                UpdateStatusDelegate updateStatusDel = new UpdateStatusDelegate(GetPasswordStatus);
-                IAsyncResult asyncRes = updateStatusDel.BeginInvoke(null, null);
-                updateStatusDel.EndInvoke(asyncRes);
-                
-                UpdateStatus();
-            }
-        }
-
-        private void OnMenuHIBPClear(object sender, EventArgs e)
-        {
-            MainForm mainForm = HIBPOfflineCheckExt.Host.MainWindow;
-            PwEntry[] selectedEntries = mainForm.GetSelectedEntries();
-
-            foreach (PwEntry pwEntry in selectedEntries)
-            {
-                pwEntry.Strings.Remove(PluginOptions.ColumnName);
-            }
-
-            mainForm.UpdateUI(false, null, false, null, true, null, true);
         }
     }
 }

--- a/HIBPOfflineCheckOptions.cs
+++ b/HIBPOfflineCheckOptions.cs
@@ -9,7 +9,7 @@ namespace HIBPOfflineCheck
     public partial class HIBPOfflineCheckOptions : Form
     {
         private HIBPOfflineCheckExt ext;
-        private Options options;
+        private Options _options;
 
         public HIBPOfflineCheckOptions(HIBPOfflineCheckExt ext)
         {
@@ -19,50 +19,43 @@ namespace HIBPOfflineCheck
 
         private void HIBPOfflineCheckOptions_Load(object sender, EventArgs e)
         {
-            this.Icon = AppIcons.Default;
+            Icon = AppIcons.Default;
 
             pb_BannerImage.Image = BannerFactory.CreateBanner(pb_BannerImage.Width, pb_BannerImage.Height, 
                 BannerStyle.Default, Properties.Resources.B48x48_KOrganizer, 
                 "HIBP Offline Check Options", "Manage plugin settings.");
 
-            options = ext.LoadOptions();
+            _options = ext.LoadOptions();
 
-            textBoxFileName.Text = options.HIBPFileName;
-            textBoxColumnName.Text = options.ColumnName;
-            textBoxSecureText.Text = options.SecureText;
-            textBoxInsecureText.Text = options.InsecureText;
-            checkBoxBreachCountDetails.Checked = options.BreachCountDetails;
-            checkBoxWarningDialog.Checked = options.WarningDialog;
-            textBoxWarningDialog.Text = options.WarningDialogText;
+            textBoxFileName.Text = _options.HIBPFileName;
+            textBoxColumnName.Text = _options.ColumnName;
+            textBoxSecureText.Text = _options.SecureText;
+            textBoxInsecureText.Text = _options.InsecureText;
+            checkBoxBreachCountDetails.Checked = _options.BreachCountDetails;
+            checkBoxWarningDialog.Checked = _options.WarningDialog;
+            textBoxWarningDialog.Text = _options.WarningDialogText;
+            textBoxWarningDialog.Enabled = checkBoxWarningDialog.Checked;
 
             textBoxFileName.Select();
             textBoxFileName.Select(0, 0);
 
-            if (checkBoxWarningDialog.Checked == false)
-            {
-                textBoxWarningDialog.Enabled = false;
-            }
-            else
-            {
-                textBoxWarningDialog.Enabled = true;
-            }
         }
 
         private void buttonOK_Click(object sender, EventArgs e)
         {
-            options.HIBPFileName = textBoxFileName.Text;
-            options.ColumnName = textBoxColumnName.Text;
-            options.SecureText = textBoxSecureText.Text;
-            options.InsecureText = textBoxInsecureText.Text;
-            options.BreachCountDetails = checkBoxBreachCountDetails.Checked;
-            options.WarningDialog = checkBoxWarningDialog.Checked;
-            options.WarningDialogText = textBoxWarningDialog.Text;
+            _options.HIBPFileName = textBoxFileName.Text;
+            _options.ColumnName = textBoxColumnName.Text;
+            _options.SecureText = textBoxSecureText.Text;
+            _options.InsecureText = textBoxInsecureText.Text;
+            _options.BreachCountDetails = checkBoxBreachCountDetails.Checked;
+            _options.WarningDialog = checkBoxWarningDialog.Checked;
+            _options.WarningDialogText = textBoxWarningDialog.Text;
 
             var standardFields = PwDefs.GetStandardFields();
 
             foreach (string key in standardFields)
             {
-                if (key == options.ColumnName)
+                if (key == _options.ColumnName)
                 {
                     MessageBox.Show("Column name conflicts with KeePass columns", 
                         " Invalid column name", MessageBoxButtons.OK, MessageBoxIcon.Error);
@@ -70,13 +63,13 @@ namespace HIBPOfflineCheck
                 }
             }
 
-            ext.SaveOptions(options);
-            this.Close();
+            ext.SaveOptions(_options);
+            Close();
         }
 
         private void buttonCancel_Click(object sender, EventArgs e)
         {
-            this.Close();
+            Close();
         }
 
         private void buttonBrowse_Click(object sender, EventArgs e)
@@ -92,14 +85,7 @@ namespace HIBPOfflineCheck
 
         private void checkBoxWarningDialog_CheckedChanged(object sender, EventArgs e)
         {
-            if (checkBoxWarningDialog.Checked == false)
-            {
-                textBoxWarningDialog.Enabled = false;
-            }
-            else
-            {
-                textBoxWarningDialog.Enabled = true;
-            }
+            textBoxWarningDialog.Enabled = checkBoxWarningDialog.Checked;
         }
     }
 }

--- a/HIBPOfflineColumnProv.cs
+++ b/HIBPOfflineColumnProv.cs
@@ -1,0 +1,253 @@
+﻿using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+using System.Windows.Forms;
+using KeePass.Forms;
+using KeePass.Plugins;
+using KeePass.UI;
+using KeePass.Util.Spr;
+using KeePassLib;
+using KeePassLib.Security;
+
+namespace HIBPOfflineCheck
+{
+    public sealed class HIBPOfflineColumnProv : ColumnProvider
+    {
+        private string Status { get; set; }
+        private PwEntry PasswordEntry { get; set; }
+
+        public IPluginHost Host { private get; set; }
+        public Options PluginOptions { private get; set; }
+
+        private bool _insecureWarning;
+        private bool _passwordEdited;
+
+        public HIBPOfflineColumnProv()
+        {
+            HIBPOfflineCheckExt.Host.MainWindow.EntryContextMenu.Opening += ContextMenuStrip_Opening;
+        }
+
+        public override string[] ColumnNames => new [] { PluginOptions.ColumnName };
+
+        public override bool SupportsCellAction(string strColumnName)
+        {
+            return (strColumnName == PluginOptions.ColumnName);
+        }
+
+        private void GetPasswordStatus()
+        {
+            var latestFile = PluginOptions.HIBPFileName;
+            if (!File.Exists(latestFile))
+            {
+                Status = "HIBP file not found";
+                return;
+            }
+
+            string pwdShaStr;
+            using (var sha1 = new SHA1CryptoServiceProvider())
+            {
+                var context = new SprContext(PasswordEntry, Host.Database, SprCompileFlags.All);
+                var password = SprEngine.Compile(PasswordEntry.Strings.GetSafe(PwDefs.PasswordField).ReadString(), context);
+
+                var pwdShaBytes = sha1.ComputeHash(Encoding.UTF8.GetBytes(password));
+                var sb = new StringBuilder(2 * pwdShaBytes.Length);
+
+                foreach (var b in pwdShaBytes)
+                {
+                    sb.AppendFormat("{0:X2}", b);
+                }
+                pwdShaStr = sb.ToString();
+            }
+
+            using (var fs = File.OpenRead(latestFile))
+            using (var sr = new StreamReader(fs))
+            {
+                try
+                {
+                    Status = PluginOptions.SecureText;
+                    var shaLen = pwdShaStr.Length;
+
+                    var low = 0L;
+                    var high = fs.Length;
+
+                    while (low <= high)
+                    {
+                        var middle = (low + high + 1) / 2;
+                        fs.Seek(middle, SeekOrigin.Begin);
+
+                        // Resync with base stream after seek
+                        sr.DiscardBufferedData();
+
+                        var line = sr.ReadLine();
+
+                        if (sr.EndOfStream) break;
+
+                        // We may have read only a partial line so read again to make sure we get a full line
+                        if (middle > 0) line = sr.ReadLine() ?? string.Empty;
+
+                        if (line != null)
+                        {
+                            var compare = string.Compare(pwdShaStr, line.Substring(0, shaLen), StringComparison.Ordinal);
+
+                            if (compare < 0)
+                            {
+                                high = middle - 1;
+                            }
+                            else if (compare > 0)
+                            {
+                                low = middle + 1;
+                            }
+                            else
+                            {
+                                var tokens = line.Split(':');
+                                Status = PluginOptions.InsecureText;
+                                _insecureWarning = true;
+
+                                if (PluginOptions.BreachCountDetails)
+                                {
+                                    Status += " (password count: " + tokens[1].Trim() + ")";
+                                }
+
+                                break;
+                            }
+                        }
+                    }
+                }
+                catch
+                {
+                    Status = "Failed to read HIBP file";
+                }
+            }
+        }
+
+        public override void PerformCellAction(string strColumnName, PwEntry pe)
+        {
+            if (strColumnName == null || pe == null) { Debug.Assert(false); return; }
+            if (strColumnName != PluginOptions.ColumnName) { return; }
+
+            PasswordEntry = pe;
+
+            GetPasswordStatus();
+            UpdateStatus();
+        }
+
+        private void PwdTouchedHandler(object sender, ObjectTouchedEventArgs e)
+        {
+            PwEntry pe = sender as PwEntry;
+            if (e.Modified)
+            {
+                _passwordEdited = true;
+                PerformCellAction(PluginOptions.ColumnName, pe);
+            }
+        }
+
+        public override string GetCellData(string strColumnName, PwEntry pe)
+        {
+            if (pe == null) return string.Empty;
+
+            //pe.Touched -= PwdTouchedHandler;
+            pe.Touched += PwdTouchedHandler;
+
+            return pe.Strings.GetSafe(PluginOptions.ColumnName).ReadString();
+        }
+
+        private void UpdateStatus()
+        {
+            MainForm mainForm = HIBPOfflineCheckExt.Host.MainWindow;
+            ListView lv = (mainForm.Controls.Find("m_lvEntries", true)[0] as ListView);
+
+            UIScrollInfo scroll = UIUtil.GetScrollInfo(lv, true);
+
+            PasswordEntry.Strings.Set(PluginOptions.ColumnName, new ProtectedString(true, Status));
+
+            mainForm.UpdateUI(false, null, false, null, true, null, true);
+
+            UIUtil.Scroll(lv, scroll, true);
+
+            if (_insecureWarning && _passwordEdited && PluginOptions.WarningDialog)
+            {
+                MessageBox.Show(PluginOptions.WarningDialogText,
+                    "HIBP Offline Check", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            }
+
+            _insecureWarning = false;
+            _passwordEdited = false;
+        }
+
+        private void ContextMenuStrip_Opening(object sender, CancelEventArgs e)
+        {
+            MainForm mainForm = HIBPOfflineCheckExt.Host.MainWindow;
+            ToolStripItem[] items = mainForm.EntryContextMenu.Items.Find("m_ctxEntryMassModify", true);
+
+            if (items.Length > 0)
+            {
+                ToolStripMenuItem ctxEntryMassModify = items[0] as ToolStripMenuItem;
+
+                if (ctxEntryMassModify != null)
+                {
+                    ToolStripItem[] hibpItems = ctxEntryMassModify.DropDownItems.Find("m_ctxEntryHIBP", true);
+
+                    if (hibpItems.Length == 0)
+                    {
+                        ToolStripSeparator separator = new ToolStripSeparator();
+                        ctxEntryMassModify.DropDownItems.Add(separator);
+
+                        ToolStripMenuItem hibpMenuItem = new ToolStripMenuItem()
+                        {
+                            Name = "m_ctxEntryHIBP",
+                            Text = "Have I been pwned?"
+                        };
+
+                        hibpMenuItem.Click += OnMenuHIBP;
+                        ctxEntryMassModify.DropDownItems.Add(hibpMenuItem);
+
+                        ToolStripMenuItem hibpClearMenuItem = new ToolStripMenuItem()
+                        {
+                            Name = "m_ctxEntryHIBPClear",
+                            Text = "Clear pwned status"
+                        };
+
+                        hibpClearMenuItem.Click += OnMenuHIBPClear;
+                        ctxEntryMassModify.DropDownItems.Add(hibpClearMenuItem);
+
+                    }
+                }
+            }
+        }
+
+        private delegate void UpdateStatusDelegate();
+
+        private void OnMenuHIBP(object sender, EventArgs e)
+        {
+            MainForm mainForm = HIBPOfflineCheckExt.Host.MainWindow;
+            PwEntry[] selectedEntries = mainForm.GetSelectedEntries();
+
+            foreach (PwEntry pwEntry in selectedEntries)
+            {
+                PasswordEntry = pwEntry;
+
+                UpdateStatusDelegate updateStatusDel = GetPasswordStatus;
+                IAsyncResult asyncRes = updateStatusDel.BeginInvoke(null, null);
+                updateStatusDel.EndInvoke(asyncRes);
+                
+                UpdateStatus();
+            }
+        }
+
+        private void OnMenuHIBPClear(object sender, EventArgs e)
+        {
+            MainForm mainForm = HIBPOfflineCheckExt.Host.MainWindow;
+            PwEntry[] selectedEntries = mainForm.GetSelectedEntries();
+
+            foreach (PwEntry pwEntry in selectedEntries)
+            {
+                pwEntry.Strings.Remove(PluginOptions.ColumnName);
+            }
+
+            mainForm.UpdateUI(false, null, false, null, true, null, true);
+        }
+    }
+}

--- a/Options.cs
+++ b/Options.cs
@@ -1,24 +1,19 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace HIBPOfflineCheck
+﻿namespace HIBPOfflineCheck
 {
     public class Options
     {
         public static class Names
         {
-            public static string PluginNamespace = "HIBPOfflineCheck";
-            public static string HIBPFileName = PluginNamespace + ".HIBPFileName";
-            public static string ColumnName = PluginNamespace + ".ColumnName";
-            public static string SecureText = PluginNamespace + ".SecureText";
-            public static string InsecureText = PluginNamespace + ".InsecureText";
-            public static string BreachCountDetails = PluginNamespace + ".BreachCountDetails";
-            public static string WarningDialog = PluginNamespace + ".WarningDialog";
-            public static string WarningDialogText = PluginNamespace + ".WarningDialogText";
-        }
+            private const string PLUGIN_NAMESPACE = "HIBPOfflineCheck";
 
-        public Options() { }
+            public const string HIBP_FILE_NAME = PLUGIN_NAMESPACE + ".HIBPFileName";
+            public const string COLUMN_NAME = PLUGIN_NAMESPACE + ".ColumnName";
+            public const string SECURE_TEXT = PLUGIN_NAMESPACE + ".SecureText";
+            public const string INSECURE_TEXT = PLUGIN_NAMESPACE + ".InsecureText";
+            public const string BREACH_COUNT_DETAILS = PLUGIN_NAMESPACE + ".BreachCountDetails";
+            public const string WARNING_DIALOG = PLUGIN_NAMESPACE + ".WarningDialog";
+            public const string WARNING_DIALOG_TEXT = PLUGIN_NAMESPACE + ".WarningDialogText";
+        }
 
         public string HIBPFileName { get; set; }
         public string ColumnName { get; set; }


### PR DESCRIPTION
- [optimize] moved guard clause to top of GetPasswordStatus method to short circuit before computing hash
- [bugfix] fixed the default filename
- [bugfix] fixed options defaults - GetString wasn't working properly with empty strings
- [cleanup] simplified logic in options dialog - use checkbox state instead of explicit true/false
- [cleanup] moved HIBPOfflineColumnProv to its own file.
- [cleanup] general cleanup following resharper style recommendations