### PR TITLE
Set Status field as unprotected

### DIFF
--- a/HIBPOfflineCheck/HIBPOfflineColumnProv.cs
+++ b/HIBPOfflineCheck/HIBPOfflineColumnProv.cs
@@ -303,7 +303,7 @@ namespace HIBPOfflineCheck
 
             UIScrollInfo scroll = UIUtil.GetScrollInfo(lv, true);
 
-            PasswordEntry.Strings.Set(PluginOptions.ColumnName, new ProtectedString(true, Status));
+            PasswordEntry.Strings.Set(PluginOptions.ColumnName, new ProtectedString(false, Status));
 
             mainForm.UpdateUI(false, null, false, null, true, null, true);
 


### PR DESCRIPTION



When setting the field/column HIBP is storing the pwned status as a protected string. This is a bit counter productive as it hides the breach status (which in and of itself does not contain the password) behind asterisks ******. What good is it to check the breach status if you can't see the result without extra effort?

This mainly affects views that don't use the standard "Column" view (which defaults to unmasking the field.). Such as the text view (and plugins that make use of the text view) and plugins such as EnhancedKeepassEntryView that provide alternate views/layouts. 

**Examples:**

**EnhancedEntryView Plugin**
![2019-07-31_11-46-36](https://user-images.githubusercontent.com/6519152/62234193-c9de6000-b38f-11e9-897e-f53896298e4a.jpg)

**Keepass Text View**
![2019-07-31_11-46-55](https://user-images.githubusercontent.com/6519152/62234194-c9de6000-b38f-11e9-8c5a-e7d4b71176bd.jpg)

**Other plugin using text view**
![2019-07-31_11-47-29](https://user-images.githubusercontent.com/6519152/62234196-c9de6000-b38f-11e9-8004-0765135b89bc.jpg)