### PR TITLE
Preserve the Last Modification Time when an entry is Checked, Cleared or Excluded.

### DIFF
--- a/HIBPOfflineCheck/HIBPOfflineColumnProv.cs
+++ b/HIBPOfflineCheck/HIBPOfflineColumnProv.cs
@@ -313,7 +313,9 @@ namespace HIBPOfflineCheck
                 pe.Touched -= PwdTouchedHandler;
                 pe.Touched += PwdTouchedHandler;
 
+                var lastModificationTime = pe.LastModificationTime;
                 pe.Touch(true);
+                pe.LastModificationTime = lastModificationTime;
             }
 
             ResetState();


### PR DESCRIPTION
Tested normal entry editing (_Last Modification Time_ is updated) and also password Check/Clear/Exclude via _Have I been pwned?_ and it's working as expected (_Last Modification Time_ is preserved).